### PR TITLE
Merge Pull Request #10 from jcloghesy/FixDynamicCSS

### DIFF
--- a/styles/body.scss
+++ b/styles/body.scss
@@ -90,7 +90,7 @@
 }
 
 
-@media only screen and (min-width:992px) {
+@media only screen and (max-width:992px) {
   .container {
     display: flex;
     align-items:center;
@@ -118,23 +118,23 @@
   }
 
   .task-input {
-  display:flex;
-  margin-top:1em;
-  margin-bottom:1em;
-}
+    display:flex;
+    margin-top:1em;
+    margin-bottom:1em;
+  }
 
-.add-task {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
+  .add-task {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
 
   .box-1, .box-2, .box-3, .box-4 {
-  display: flex;
-  justify-content: center;
-  flex-direction: column;
-  padding: 1em;
-
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+    padding: 1em;
+  }
   .taskbox {
     display: flex;
     justify-content: space-around;
@@ -148,4 +148,4 @@
     font-family: 'Roboto', sans-serif;
   }
 }
-}
+


### PR DESCRIPTION
- Fix issue of several elements resizing/reacting oppositely to expect with screen resize
-  Address for all pages - main task, login, etc. and multiple page sections
-  Specifically address when there is an INCREASE in browser screen size, elements became SMALLER horizontally or WRAP/STACK (taking up two lines and not one line) and vice versa
- Ensure correct spacing (indents) in code are present w/small updates 